### PR TITLE
add donot_install_server_hack in cmocka test, solution included.

### DIFF
--- a/cmocka/Makefile.am
+++ b/cmocka/Makefile.am
@@ -11,7 +11,8 @@ bsd_get_platform_name_test
 serverhack_program=serverhack_test \
 param_test
 
-script_program=automake_disable_libnotify_test.sh
+script_program=automake_disable_libnotify_test.sh \
+donot_install_growlserverhack_test.sh
 
 check_PROGRAMS=$(program) $(serverhack_program)
 ### this will execute the test

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,5 +1,7 @@
 AM_CPPFLAGS=-I$(top_srcdir)/src
-bin_PROGRAMS=growlnotify GrowlServerHack
+bin_PROGRAMS=growlnotify 
+# this will be compile but not installed
+check_PROGRAMS=GrowlServerHack
 
 growlnotify_SOURCES=growlnotify.c ../src/libgrowl.c
 


### PR DESCRIPTION
Just a simple solution, if you know how. In Makefile.am
check_PROGRAMS=, will not be installed in make install. 